### PR TITLE
fix: add 'c' to ignored dependencies in Knip configuration

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -2,6 +2,7 @@ import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
 	exclude: ['duplicates', 'optionalPeerDependencies'],
+	ignoreDependencies: ['c'],
 	workspaces: {
 		'.': {
 			ignoreDependencies: ['@changesets/config', '@changesets/write'],


### PR DESCRIPTION
add's the `c` virtual module (knip false positive) to the filter list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option that lets you exclude specified dependencies, enhancing control and flexibility over dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->